### PR TITLE
improved Manualcontrol

### DIFF
--- a/00_pipeline_launcher.R
+++ b/00_pipeline_launcher.R
@@ -278,8 +278,7 @@ switch(args[1],
               help = "Generate plots automatically if 'FALSE'. Otherwise, the
 			  user needs to interact with 03_1_manualControls_<INPUT_DATASET>_pipeline.Rmd
 			  	(default: FALSE)"
-          )
-      ),
+          ),
         make_option(
           c("-m", "--mito_thresholds"),
           action = "store",
@@ -312,6 +311,7 @@ switch(args[1],
           help = "ONLY USED WITH --manual
           The list of the thresholds for the number of features, as a comma-separated list."
         )
+      )
       parsed <- OptionParser(
           usage = "Usage: \n\t%prog filter? [--flag <flag_arg>]",
           option_list = option_list3,
@@ -512,10 +512,10 @@ if (TRUE){
     clust_res = if (exists("CLUST_RES")) as.numeric(CLUST_RES) else opt$options$selected_resolution
     clust_meth = if (exists("CLUST_METH")) as.integer(CLUST_METH) else opt$options$algo_clustering
     # advanced filter pipeline variables  --------
-    mito_thresholds = strsplit(if (exists("MITO_THRESHOLDS")) MITO_THRESHOLDS else opt$options$mito_thresholds, ",")
-    ribo_thresholds = strsplit(if (exists("RIBO_THRESHOLDS")) RIBO_THRESHOLDS else opt$options$ribo_thresholds, ",")
-    umi_thresholds = strsplit(if (exists("UMI_THRESHOLDS")) UMI_THRESHOLDS else opt$options$umi_thresholds, ",")
-    feature_thresholds = strsplit(if (exists("FEATURE_THRESHOLDS")) FEATURE_THRESHOLDS else opt$options$feature_thresholds, ",")
+    mito_thresholds = as.numeric(unlist(strsplit(if (exists("MITO_THRESHOLDS")) MITO_THRESHOLDS else opt$options$mito_thresholds, ",")))
+    ribo_thresholds = as.numeric(unlist(strsplit(if (exists("RIBO_THRESHOLDS")) RIBO_THRESHOLDS else opt$options$ribo_thresholds, ",")))
+    umi_thresholds = as.numeric(unlist(strsplit(if (exists("UMI_THRESHOLDS")) UMI_THRESHOLDS else opt$options$umi_thresholds, ",")))
+    feature_thresholds = as.numeric(unlist(strsplit(if (exists("FEATURE_THRESHOLDS")) FEATURE_THRESHOLDS else opt$options$feature_thresholds, ",")))
     # deg pipeline variables ---------------------
     top_markers = opt$options$markers_number
     # doublets removal ---------------------------
@@ -561,7 +561,7 @@ switch(args[1],
        "filters" = {
            if (opt$options$manual) {
                rmarkdown::render(
-                   "03_1_manualControls__pipeline.Rmd",
+                   "03_1_manualControls_pipeline.Rmd",
                    output_file = paste0(PATH_OUT_HTML, "03_1_manualControls_", DATASET, "_", Sys.Date(), ".html")
                )
            } else {

--- a/03_1_manualControls_pipeline.Rmd
+++ b/03_1_manualControls_pipeline.Rmd
@@ -167,13 +167,13 @@ cplt <- AddMetaData(object = cplt, metadata = metadata$percent.ribo,   col.name 
 
 # Mitochondrial exploration 
 
-```{r defineGroupsMito, out.width="50%"}
-mito_thresholds = c(0.8,5,15,70)
-# Créez un vecteur de noms de groupe
-
+```{r defineGroupsMito, out.width="50%", fig.align='default', fig.show='hold'}
 cplt@meta.data[,"mito_groups"] <- set_thresh(mito_thresholds, cplt@meta.data$percent.mito, "mito")
-mito_thresholds = append(mito_thresholds, 100)
-VlnPlot(cplt, features = c("percent.mito")) +
+# Must add an upper bound in order for the last group to be displayed
+max_mito <- max(cplt@meta.data$percent.mito)
+mito_thresholds <- append(mito_thresholds, ceiling(max_mito + max_mito*0.05))
+
+plot1 <- VlnPlot(cplt, features = c("percent.mito")) +
   lapply(mito_thresholds, threshline) +
   ggtitle("Mitochondrial expression\npercentage") +
   theme(axis.title.x = element_blank(),
@@ -185,6 +185,12 @@ VlnPlot(cplt, features = c("percent.mito")) +
   scale_y_continuous(labels = scales::percent_format(scale = 1)) +
   coord_cartesian(ylim = c(0, 100)) +
   mapply(threshtext, mito_thresholds, seq_along(mito_thresholds), "mito")
+plot2 <- plot1 +
+    ggtitle("Zoom in") +
+    coord_cartesian(ylim = c(0, 15))
+
+plot1
+plot2
 ```
 
 Groups' size:
@@ -236,9 +242,9 @@ knitr::include_graphics(paste0(PATH_OUT_FIG, "/01_qc_vln-riboPercentage-1.png"))
 ```
 
 ```{r defineGroupsRibo, out.width="50%"}
-ribo_thresholds <- c(12,35)
-
 cplt@meta.data[, "ribo_groups"] <- set_thresh(ribo_thresholds, cplt@meta.data$percent.ribo, "ribo")
+max_ribo <- max(cplt@meta.data$percent.ribo)
+ribo_thresholds <- append(ribo_thresholds, ceiling(max_ribo + max_ribo*0.05))
 
 VlnPlot(cplt, features = c("percent.ribo")) +
     lapply(ribo_thresholds, threshline) +
@@ -304,9 +310,9 @@ knitr::include_graphics(paste0(PATH_OUT_FIG, "/01_qc_vln-countRNA-1.png"))
 ```
 
 ```{r defineGroupsUMI, out.width="50%"}
-umi_thresholds <- c(7000,55000)
-
 cplt@meta.data[, "umi_groups"] <- set_thresh(umi_thresholds, cplt@meta.data$nCount_RNA, "umi")
+max_umi <- max(cplt@meta.data$nCount_RNA)
+umi_thresholds <- append(umi_thresholds, ceiling(max_umi + max_umi*0.05))
 
 VlnPlot(cplt, features = c("nCount_RNA")) +
   lapply(umi_thresholds, threshline) +
@@ -371,9 +377,10 @@ ggplot(data = cellsData,
 knitr::include_graphics(paste0(PATH_OUT_FIG, "/01_qc_vln-featureRNA-1.png"))
 ```
 
-```{r defineGroupsfeature, out.width="50%"}
-feature_thresholds <- c(2000,6500)
+```{r defineGroupsfeature, out.width="50%", fig.align = "default", fig.show = "hold"}
 cplt@meta.data[, "feature_groups"] <- set_thresh(feature_thresholds, cplt@meta.data$nFeature_RNA, "feature")
+max_feature <- max(cplt@meta.data$nFeature_RNA)
+feature_thresholds <- append(feature_thresholds, ceiling(max_feature + max_feature*0.05))
 
 VlnPlot(cplt, features = c("nFeature_RNA")) +
     lapply(feature_thresholds, threshline) +
@@ -393,7 +400,7 @@ feature_groups <- sort(unique(cplt$feature_groups))
 table(cplt@meta.data$feature_groups)
 ```
 
-```{r groupsFeature, out.width="50%", fig.align='default', fig.show='hold'}
+```{r groupsFeature, out.width="50%"}
 cellsData <- data.frame(umapCoord, cplt@meta.data$nFeature_RNA, cplt@meta.data$feature_groups)
 colnames(cellsData) <- c(colnames(umapCoord), "nFeature_RNA", "group_feature")
 

--- a/plotting_functions.R
+++ b/plotting_functions.R
@@ -98,7 +98,8 @@ highlightClusterPlot <- function(clusterName, seuratObject, reduction = "umap") 
 set_thresh <- function(thresholds, metadata, metric){
   group_names <- paste0("gp", 1:(length(thresholds)+1), "_", metric)
 
-  # Utilisez la fonction cut pour attribuer les groupes en fonction des seuils
+  # cut() breaks down a data frame column according to the submitted thresholds (infinites are needed to avoid setting minimum and maximum thresholds), 
+  # then returns a column with the labels of each groups
   return(cut(metadata, include.lowest=T, breaks=c(-Inf,thresholds, Inf), labels = group_names))
 }
 


### PR DESCRIPTION
Specifies the thresholds once and the script takes care of the rest.

* Added four helper functions to generate report graphs with arbitrary vectors
* Added a zoom-in graph for the mitochondrial expression graph
* Added four command lines arguments and config file parameters to set the thresholds of the different groups of:
    * percent mito
    * percent ribo
    * nCounts
    * nFeatures

Intended use : adjust the thresholds using the command line, then when they are definitive add them to the config file.
It is still possible to adjust the thresholds using Rstudio, simply assign the variable `[metric]_thresholds`, which must be a vector.
