### PR TITLE
BUGFIX force reticulate to use env's python

### DIFF
--- a/07_meld_pipeline.Rmd
+++ b/07_meld_pipeline.Rmd
@@ -65,6 +65,8 @@ title: "Differential Abundance using MELD"
 ```{r setup, include = FALSE}
 library(knitr)
 library(reticulate)
+# we force the use of our env's python. We faced situation where reticulates were using the banse env's python
+reticulate::use_python(system("which python", intern = TRUE))
 knitr::knit_engines$set(python = reticulate::eng_python)
 options(knitr.purl.inline = TRUE)
 knitr::opts_chunk$set(


### PR DESCRIPTION
reticulate was not able to load python's library.
It was taking python from another directory.
We trick it by forcing reticulate to look at the env python.