### PR TITLE
Add error handling for genes_of_interest file in 05_annotDEAviz_pipeline

### DIFF
--- a/05_annotDEAviz_pipeline.Rmd
+++ b/05_annotDEAviz_pipeline.Rmd
@@ -363,7 +363,12 @@ datatable(topNmarkers, rownames = FALSE, filter = "top", options = list(pageLeng
 
 ```{r load-goi-list, eval=!is.null(genes_of_interest), echo=!is.null(genes_of_interest)}
 # Load list of genes of interest
-goi <- read.table(genes_of_interest)
+goi <- try(read.table(genes_of_interest), silent = TRUE)
+
+if (inherits(goi, "try-error")) {
+    goi <- read.table(genes_of_interest, sep=",", colClasses=c("character", "NULL"))
+}
+
 goiList <- goi$V1
 
 genesToRemove <- goiList[!(goiList %in% rownames(fltd))]


### PR DESCRIPTION
This commit introduces a "try-catch" in 05_annotDEAviz_pipeline.Rmd to handle various formats of the genes_of_interest file. It first attempts to read the file with default settings and, if that fails, tries reading with specified comma separator and column classes. 