### PR TITLE
check if OBSERVE_FEATURES is well included in filtered dataset

### DIFF
--- a/04_additionalControls.Rmd
+++ b/04_additionalControls.Rmd
@@ -348,24 +348,32 @@ without blindly removing all cells with a somatic expression of its marker gene.
 ```{r observe-genes-umap, result='asis', fig.align='default', fig.size='50%'}
 corr_table <- as.data.frame(fread(file.path(PATH_INPUT_LABDATA, "features.tsv.gz"), header = FALSE, sep = "\t", col.names = c("ENSid", "GeneName", "Type")))
 
+# Create a variable to store gene names present in the assay data
+available_genes <- rownames(GetAssayData(singlets, slot = "data"))
+
 invisible(lapply(obs_list, function(gene_name){
-  cells_gene_pos <- which(GetAssayData(singlets, slot="data")[gene_name,]>0)
+  # Check if gene_name is in the available_genes
+  if (gene_name %in% available_genes) {
+    cells_gene_pos <- which(GetAssayData(singlets, slot="data")[gene_name,]>0)
 
-  cat("#### ", corr_table$GeneName[match(gene_name, corr_table$ENSid)], " distribution \n")
+    cat("#### ", corr_table$GeneName[match(gene_name, corr_table$ENSid)], " distribution \n")
 
-  Idents(singlets) <- clustOfInterest
-  print(FeaturePlot(fltd, features=gene_name, order=T))
+    Idents(singlets) <- clustOfInterest
+    print(FeaturePlot(fltd, features=gene_name, order=T))
 
-  p <- DimPlot( singlets,
-         reduction = "umap",
-         cells.highlight = cells_gene_pos,
-         cols.highlight = "#FF000088", 
-         sizes.highlight = Seurat:::AutoPointSize(singlets)*4, 
-         order = cells_gene_pos,  # Plot highlighted cells last
-         group.by=NULL) + theme(legend.position="none")
-  print(LabelClusters(p, id = "ident",  fontface = "bold", size = 5))
+    p <- DimPlot( singlets,
+           reduction = "umap",
+           cells.highlight = cells_gene_pos,
+           cols.highlight = "#FF000088", 
+           sizes.highlight = Seurat:::AutoPointSize(singlets)*4, 
+           order = cells_gene_pos,  # Plot highlighted cells last
+           group.by=NULL) + theme(legend.position="none")
+    print(LabelClusters(p, id = "ident",  fontface = "bold", size = 5))
 
-  cat(" \n \n") # Required for '.tabset'
+    cat(" \n \n") # Required for '.tabset'
+  } else {
+    cat("#### ", gene_name, " is not available in the dataset \n \n")
+  }
 })
 )
 ```
@@ -374,17 +382,30 @@ invisible(lapply(obs_list, function(gene_name){
 
 ```{r observe-genes-table}
 sorted_clust_list <- sort(as.list(unique(singlets@meta.data[clustOfInterest]))[[1]])
-df_obs <- data.frame("cluster"=sorted_clust_list)
+df_obs <- data.frame("cluster" = sorted_clust_list)
+
+# Create a variable to store gene names present in the assay data
+available_genes <- rownames(GetAssayData(object = singlets, slot = "data"))
 
 for(gene_name in obs_list) {
-  df_obs[[paste0(corr_table$GeneName[match(gene_name, corr_table$ENSid)], "+_cells")]] <- sapply(sorted_clust_list, function(clust) {
-    sum(GetAssayData(object = singlets, slot = "data")[gene_name,which(singlets@meta.data[clustOfInterest]==clust)]>0)
-  })
+  if (gene_name %in% available_genes) {
+    # Proceed with calculations if gene_name is present
+    gene_cells_column_name <- paste0(corr_table$GeneName[match(gene_name, corr_table$ENSid)], "+_cells")
+    df_obs[[gene_cells_column_name]] <- sapply(sorted_clust_list, function(clust) {
+      sum(GetAssayData(object = singlets, slot = "data")[gene_name, which(singlets@meta.data[clustOfInterest] == clust)] > 0)
+    })
+  } else {
+    # If the gene is not present, fill with NA or zeros
+    gene_cells_column_name <- paste0("Missing_", gene_name, "+_cells")  # Adjusted column name for missing genes
+    df_obs[[gene_cells_column_name]] <- rep(NA, length(sorted_clust_list))  # Use NA or 0 depending on how you want to represent missing data
+  }
 }
 
-df_obs$total_cells <- sapply(sorted_clust_list, function(clust) {length(which(singlets@meta.data[clustOfInterest]==clust))})
+df_obs$total_cells <- sapply(sorted_clust_list, function(clust) {
+  length(which(singlets@meta.data[clustOfInterest] == clust))
+})
 
-knitr::kable(df_obs, caption="Number of cells expressing the genes of interest in each clusters. A cell can express multiple, or even all these genes.") %>% 
+knitr::kable(df_obs, caption = "Number of cells expressing the genes of interest in each cluster. A cell can express multiple, or even all, these genes.") %>%
   kable_styling(bootstrap_options = c("striped", "hover"), full_width = FALSE)
 ```
 


### PR DESCRIPTION
If the OBSERVE_FEATURES marker were missing after QC filters, the lines corresponding to identify their locations in cluster plots were failing. I added the check of their presences.